### PR TITLE
fix: nils in lists handled incorrectly

### DIFF
--- a/libs/redis-codec.lua
+++ b/libs/redis-codec.lua
@@ -58,8 +58,8 @@ local function innerDecode(chunk, index)
     for i = 1, len do
       local value
       value, index = innerDecode(chunk, index)
-      if not value then return end
-      list[i] = value
+      --if not value then return end
+      list[i] = value or false
     end
     return list, index
   else


### PR DESCRIPTION
replace nils in lists with false, rather than aborting parsing